### PR TITLE
Update com.rafaelmardojai.Blanket.json, blueprint to 0.16.0

### DIFF
--- a/com.rafaelmardojai.Blanket.json
+++ b/com.rafaelmardojai.Blanket.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "com.rafaelmardojai.Blanket",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "47",
+    "runtime-version" : "48",
     "sdk" : "org.gnome.Sdk",
     "command" : "blanket",
     "finish-args" : [
@@ -31,7 +31,7 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-                    "tag": "v0.10.0",
+                    "tag": "v0.16.0",
                     "commit": "2a39a16391122af2f3d812e478c1c1398c98b972"
                 }
             ]

--- a/com.rafaelmardojai.Blanket.json
+++ b/com.rafaelmardojai.Blanket.json
@@ -32,7 +32,7 @@
                     "type": "git",
                     "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
                     "tag": "v0.16.0",
-                    "commit": "2a39a16391122af2f3d812e478c1c1398c98b972"
+                    "commit": "04ef0944db56ab01307a29aaa7303df6067cb3c0"
                 }
             ]
         },


### PR DESCRIPTION
Update runtime version to GNOME 48; should affect dark theme coloration and corner radius of window and some widgets (due to Libadwaita 1.7). Update to blueprint compiler dep is required to build successfully